### PR TITLE
Set RCTResizeMode.h into iOS

### DIFF
--- a/ios/Compressor-Bridging-Header.h
+++ b/ios/Compressor-Bridging-Header.h
@@ -2,5 +2,6 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 #import <React/RCTBridgeModule.h>
+#import <React/RCTResizeMode.h>
 #import <React/RCTEventEmitter.h>
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
- Fix Build error at ImageCompressor.swift file - Cannot find 'RCTResizeMode' in scope
